### PR TITLE
Fix output directory creation

### DIFF
--- a/build_ml_training_data.py
+++ b/build_ml_training_data.py
@@ -85,6 +85,7 @@ def main():
         combined_strategies.to_csv(strategies_path, index=False)
         print(f'✅ Saved combined strategy setups to {strategies_path}')
     if all_combined_strategies:
+        os.makedirs('results', exist_ok=True)
         all_strategies_path = os.path.join('results', 'combined_all_strategy_signals.csv')
         pd.concat(all_combined_strategies, ignore_index=True).to_csv(all_strategies_path, index=False)
         print(f'✅ Saved combined strategy signals to {all_strategies_path}')


### PR DESCRIPTION
## Summary
- ensure the `results` directory exists when saving the combined strategy signal file

## Testing
- `python -m py_compile build_ml_training_data.py`


------
https://chatgpt.com/codex/tasks/task_e_68791e1e4bd4832f9945873711b4cf78