### PR TITLE
Add pytest-based unit tests

### DIFF
--- a/tests/test_screener.py
+++ b/tests/test_screener.py
@@ -1,0 +1,47 @@
+import pandas as pd
+from unittest.mock import patch
+from screener import process_ticker
+
+
+class DummyTicker:
+    def __init__(self, ticker):
+        self.ticker = ticker
+        self.info = {
+            'fiftyTwoWeekHigh': 50,
+            'fiftyTwoWeekLow': 10,
+            'sector': 'Tech',
+        }
+
+    def history(self, period="21d", interval="1d"):
+        data = {
+            'Open': [10] * 21,
+            'High': [11] * 21,
+            'Low': [9] * 21,
+            'Close': [10] * 21,
+            'Volume': [200000] * 21,
+        }
+        return pd.DataFrame(data)
+
+
+@patch('screener.yf.Ticker', return_value=DummyTicker('FAKE'))
+def test_process_ticker_returns_data(mock_yf):
+    result = process_ticker('FAKE')
+    assert result is not None
+    assert result['Ticker'] == 'FAKE'
+    expected_keys = {
+        'Current Price',
+        'Volume',
+        'ATR',
+        'Price Action %',
+        'Volatility %',
+        'RSI 14',
+        'VWAP Deviation %',
+        'Gap %',
+        'Volume Surge %',
+        '52W High',
+        '52W Low',
+        'Sector',
+        'News Link',
+    }
+    assert expected_keys.issubset(result.keys())
+

--- a/tests/test_strategy_tester.py
+++ b/tests/test_strategy_tester.py
@@ -1,0 +1,29 @@
+import pandas as pd
+from strategy_tester import add_technical_indicators
+
+
+def test_add_technical_indicators_adds_columns():
+    data = {
+        'close': list(range(10, 40)),
+        'high': list(range(12, 42)),
+        'low': list(range(8, 38)),
+        'volume': [1000 + i for i in range(30)],
+    }
+    df = pd.DataFrame(data)
+    result = add_technical_indicators(df.copy())
+    expected_columns = [
+        'MACD Line',
+        'MACD Signal Line',
+        '9 EMA',
+        '20 EMA',
+        'RSI 14',
+        'VWAP',
+        'VWAP Deviation %',
+        'Price Action %',
+        'Volume Surge %',
+        'Volatility %',
+    ]
+    for col in expected_columns:
+        assert col in result.columns, f"{col} not in DataFrame"
+    assert len(result) == len(df)
+


### PR DESCRIPTION
## Summary
- add initial pytest tests for the strategy tester and screener modules
- mock yfinance calls in tests so no network access is required

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68791e216e54832fb78b6f43be9bae83